### PR TITLE
fix: "Eltern, die anpacken" - Startseite aktualisieren

### DIFF
--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -116,10 +116,9 @@ const sponsorLogos = Object.entries(
 
         <article class="b-card">
           <Deko name="welle" size={56} class="b-card__icon" />
-          <h3>Eltern mittendrin</h3>
+          <h3>Eltern, die anpacken</h3>
           <p>
-            Als Elterninitiative gestalten Familien den Alltag aktiv mit -
-            soviel wie passt.
+            Das pädagogische Team begleitet die Kinder beim Lernen, Spielen und Wachsen. Die Eltern kümmern sich um alles, was es drumherum braucht: bauen, reparieren, einkaufen, organisieren.
           </p>
         </article>
 


### PR DESCRIPTION
Ersetzt die veraltete Sektion "Eltern mittendrin" auf der Startseite mit dem korrekten Inhalt gemäß Issue #7.

Closes #7

Generated with [Claude Code](https://claude.ai/code)