### PR TITLE
fix: Liste in Leitbild-Section auf Mobile lesbar machen

### DIFF
--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -147,12 +147,12 @@ const sponsorLogos = Object.entries(
           und wachsen dürfen. Unsere Haltung in sechs Sätzen:
         </p>
         <ul class="leitbild-list">
-          <li><strong>Jedes Kind zählt.</strong> Mit allem, was es mitbringt.</li>
-          <li><strong>Zusammen.</strong> Kinder, Eltern, Team auf Augenhöhe.</li>
-          <li><strong>Eltern packen an.</strong> Von Konzept bis Laternenfest.</li>
-          <li><strong>Alltag ist Lernen.</strong> Was Kinder selbst tun, bleibt.</li>
-          <li><strong>Wir sehen jedes Kind.</strong> Aufmerksam, ehrlich, verlässlich.</li>
-          <li><strong>Heute für morgen.</strong> Nachhaltigkeit ist Haltung, keine Deko.</li>
+          <li><span><strong>Jedes Kind zählt.</strong> Mit allem, was es mitbringt.</span></li>
+          <li><span><strong>Zusammen.</strong> Kinder, Eltern, Team auf Augenhöhe.</span></li>
+          <li><span><strong>Eltern packen an.</strong> Von Konzept bis Laternenfest.</span></li>
+          <li><span><strong>Alltag ist Lernen.</strong> Was Kinder selbst tun, bleibt.</span></li>
+          <li><span><strong>Wir sehen jedes Kind.</strong> Aufmerksam, ehrlich, verlässlich.</span></li>
+          <li><span><strong>Heute für morgen.</strong> Nachhaltigkeit ist Haltung, keine Deko.</span></li>
         </ul>
         <WikiLink href="https://docs.kids-bonn.de/docs/ab36eedf-a7d8-4185-8066-c8ce44e42fb2/">Unser Leitbild im Wortlaut</WikiLink>
       </div>


### PR DESCRIPTION
Schließt #9

Die Listeneinträge in der „Bewusst handeln. Gemeinsam wachsen.“-Section wurden auf Mobile unlesbar dargestellt, weil `display: flex` auf dem `<li>` dazu führte, dass `<strong>` und der nachfolgende Text als separate Flex-Items behandelt wurden.

Die Lösung: Den Inhalt jedes `<li>` in ein `<span>` gewickelt, damit Fettschrift und Rest-Text gemeinsam als ein Flex-Item umbrechen.

Generated with [Claude Code](https://claude.ai/code)