### PR TITLE
fix: Mobile Overflow im Spendenquittung-Formular

### DIFF
--- a/app/src/pages/spenden.astro
+++ b/app/src/pages/spenden.astro
@@ -298,6 +298,8 @@ const spendenArten = [
     background: var(--c-bg);
     color: var(--c-ink);
     transition: border-color 140ms ease;
+    width: 100%;
+    box-sizing: border-box;
   }
   .field textarea {
     resize: vertical;


### PR DESCRIPTION
Behebt das Problem, dass die Eingabefelder "Betrag" und "Art der Spende" auf mobilen Geräten aus dem Card-Container herausragen.

## Änderungen
- `width: 100%` und `box-sizing: border-box` zu allen Formular-Inputs in `spenden.astro` hinzugefügt

Closes #11

Generated with [Claude Code](https://claude.ai/code)