### PR TITLE
fix: Link-Text "Zum KITA-NET Bonn öffnen" zu "Zum KITA-NET Bonn" ändern

### DIFF
--- a/app/src/pages/kennenlernen.astro
+++ b/app/src/pages/kennenlernen.astro
@@ -99,7 +99,7 @@ const alterOptionen = [
                 class="btn btn--outline btn--sm"
                 data-external
               >
-                Zum KITA-NET&nbsp;Bonn öffnen
+                Zum KITA-NET&nbsp;Bonn
               </a>
             </p>
           </div>


### PR DESCRIPTION
Link-Text auf der Kennenlernen-Seite korrigiert: "Zum KITA-NET Bonn öffnen" → "Zum KITA-NET Bonn".

Closes #15

Generated with [Claude Code](https://claude.ai/code)